### PR TITLE
fix: remove unnecessary `npm_token` to fix GitHub workflows.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,25 +59,3 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_REF: ${{ github.ref }}
-  release_npm:
-    name: Publish to npm
-    needs: release
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    if: needs.release.outputs.latest_commit == github.sha
-    steps:
-      - uses: actions/setup-node@v2
-        with:
-          node-version: 14.x
-      - name: Download build artifacts
-        uses: actions/download-artifact@v2
-        with:
-          name: build-artifact
-          path: dist
-      - name: Release
-        run: npx -p publib@latest publib-npm
-        env:
-          NPM_DIST_TAG: latest
-          NPM_REGISTRY: registry.npmjs.org
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -8,7 +8,6 @@ const project = new typescript.TypeScriptProject({
   authorName: 'Kaizen Conroy',
   deps: ['@actions/core', '@actions/github'],
   devDeps: ['@vercel/ncc'],
-  releaseToNpm: true,
   tsconfig: {
     compilerOptions: {
       target: 'ES2020',


### PR DESCRIPTION
Fixes #https://t.corp.amazon.com/V1277399943

The purpose of this PR is to remove the code for publishing to `npm`. Since we do not have any use case for publishing GitHub actions to `npm`.